### PR TITLE
Fix security state listener to run once

### DIFF
--- a/check-pqc.js
+++ b/check-pqc.js
@@ -72,8 +72,8 @@ const checkTLS = async (url, logStream) => {
         const client = await page.target().createCDPSession();
         await client.send('Security.enable');
 
-        // Listen for security state changes and collect detailed information
-        client.on('Security.visibleSecurityStateChanged', (event) => {
+        // Listen for security state changes once to avoid duplicate logs
+        client.once('Security.visibleSecurityStateChanged', (event) => {
             const securityState = event.visibleSecurityState;
             const certState = securityState.certificateSecurityState || {};
 


### PR DESCRIPTION
## Summary
- ensure security state event logs only once by using `once`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683a9161cb108320b0844f6b1fc61ffb