### PR TITLE
Move serverHeader variable

### DIFF
--- a/check-pqc.js
+++ b/check-pqc.js
@@ -72,6 +72,9 @@ const checkTLS = async (url, logStream) => {
         const client = await page.target().createCDPSession();
         await client.send('Security.enable');
 
+        // Capture the server header for later reporting
+        let serverHeader = 'N/A';
+
         // Listen for security state changes and collect detailed information
         client.on('Security.visibleSecurityStateChanged', (event) => {
             const securityState = event.visibleSecurityState;
@@ -117,7 +120,6 @@ const checkTLS = async (url, logStream) => {
         });
 
         // Navigate to the URL and capture response headers
-        let serverHeader = 'N/A';
         page.on('response', response => {
             const headers = response.headers();
             // Capture server header from any response, prioritizing the last one


### PR DESCRIPTION
## Summary
- capture the server header before registering the security event listener

## Testing
- `npm test` *(fails: Missing script)*
- `node check-pqc.js https://example.com` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_683a916589a8832082f85e9368f0fb43